### PR TITLE
Notify Github if git clone fails

### DIFF
--- a/actions/build.js
+++ b/actions/build.js
@@ -58,7 +58,7 @@ function cloneAndBuild(build, cb) {
 
     if (err) {
 
-      if(!build.config.docker){
+      if (!build.config.docker) {
         // An error occurred in the git clone task: report the failure to GitHub
         log.info('git clone failed - the error will be reported to Github but not saved in the build table')
         // update some fields in the build

--- a/actions/build.js
+++ b/actions/build.js
@@ -86,11 +86,6 @@ function cloneAndBuild(build, cb) {
 
       log.info(`Build log: ${build.logUrl}\n`)
 
-      // We've cloned the repo now: the GitHub token may be different from the one loaded before, update it
-      if (build.token) {
-        github.token = build.token
-      }
-
       if (build.config.notifications.slack && build.config.secretEnv.SLACK_TOKEN) {
         slack.createClient(build.config.secretEnv.SLACK_TOKEN, build.config.notifications.slack, build)
       }

--- a/actions/build.js
+++ b/actions/build.js
@@ -57,13 +57,16 @@ function cloneAndBuild(build, cb) {
     }
 
     if (err) {
-      // An error occurred in the git clone task: report the failure to GitHub
-      log.info('git clone failed - the error will be reported to Github but not saved in the build table')
-      // update some fields in the build
-      build.endedAt = new Date()
-      build.status = 'failure'
-      build.error = err
-      build.statusEmitter.emit('finish', build)
+
+      if(!build.config.docker){
+        // An error occurred in the git clone task: report the failure to GitHub
+        log.info('git clone failed - the error will be reported to Github but not saved in the build table')
+        // update some fields in the build
+        build.endedAt = new Date()
+        build.status = 'failure'
+        build.error = err
+        build.statusEmitter.emit('finish', build)
+      }
       // now exit
       return cb(err)
     }


### PR DESCRIPTION
This is my attempt to fix issue #55 : I've tried to respect the code style (no semi-colon, etc...).

I've moved the GitHub client creation at the top, fill some fields about the error in the `build` object and emitting the `finish` event if the `clone` function returns an error.
I wasn't sure on what to do in case of a Docker container, so I'm just skipping the notification at the moment. Happy to change that condition if wrong.

I've seen that there are no tests for actions yet, will create a couple in another PR.

I was thinking to write in the log something useful as

```
The disk run out of space during the checkout.
Check if the size of your repository is bigger than the Lambda limits (512 MB)
```

Any feedback is welcome.