### PR TITLE
add only on fail flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ This configuration is hardcoded in `utils/config.js` and overridden by any confi
       username: 'LambCI',
       iconUrl: 'https://lambci.s3.amazonaws.com/assets/logo-48x48.png',
       asUser: false,
+      onlyOnFail: false, // Only notify when failing, off by default
     },
   },
   build: false, // Build nothing by default except master and PRs

--- a/notifications/slack.js
+++ b/notifications/slack.js
@@ -17,6 +17,7 @@ function SlackClient(token, options, build) {
   this.username = options.username
   this.iconUrl = options.iconUrl
   this.asUser = options.asUser
+  this.onlyOnFail = options.onlyOnFail
   this.lastTs = null // Most recent timestamp
 
   this.repo = build.repo
@@ -33,7 +34,9 @@ function SlackClient(token, options, build) {
       fallback: `Started: ${build.repo} #${build.buildNum}`,
       title: `Build #${build.buildNum} started...`,
     }
-    this.statusQueue.push(status, log.logIfErr)
+    if (!this.onlyOnFail) {
+      this.statusQueue.push(status, log.logIfErr)
+    }
   })
 
   build.statusEmitter.finishTasks.push((build, cb) => {
@@ -48,7 +51,7 @@ function SlackClient(token, options, build) {
       status.fallback = `Failed: ${build.repo} #${build.buildNum} (${elapsedTxt})`
       status.title = `Build #${build.buildNum} failed (${elapsedTxt})`
       status.text = '```' + txt.replace(/```/g, "'''") + '```' // TODO: not sure best way to escape ```
-    } else {
+    } else if (!this.onlyOnFail) {
       status.color = 'good'
       status.fallback = `Success: ${build.repo} #${build.buildNum} (${elapsedTxt})`
       status.title = `Build #${build.buildNum} successful (${elapsedTxt})`


### PR DESCRIPTION
The idea is to have this flag in case we wanted to be notified in slack ONLY when it fails
We work with a lot of stacks and we're working on improving our services' notifications, we think this could help a lot for the ease of use of LambCI as a whole.

We didn't supply tests for this, do you think this is needed? We didn't also find a way to test this out on our own with a custom stack. If we had any feedback on this we could do it. Thank you!