### PR TITLE
AWS doubled the memory limit for AWS Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ future, depending on the API they settle on)
 * No root access
 * 5 min max build time
 * Bring-your-own-binaries – Lambda has a limited selection of installed software
-* 1.5GB max memory
+* 3008 MB max memory
 * Linux only
 
 You can get around many of these limitations by [configuring LambCI to send tasks to an ECS cluster](#extending-with-ecs) where you can run your builds in Docker.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ future, depending on the API they settle on)
 ## Current Limitations (due to the Lambda environment itself)
 
 * No root access
-* 5 min max build time
+* 15 min max build time
 * Bring-your-own-binaries – Lambda has a limited selection of installed software
 * 3008 MB max memory
 * Linux only


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2017/11/aws-lambda-doubles-maximum-memory-capacity-for-lambda-functions/