### PR TITLE
Updating README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ future, depending on the API they settle on)
 ## Current Limitations (due to the Lambda environment itself)
 
 * No root access
-* 5 min max build time
+* 15 min max build time
 * Bring-your-own-binaries – Lambda has a limited selection of installed software
-* 1.5GB max memory
+* 3008MB max memory
 * Linux only
 
-You can get around many of these limitations by [configuring LambCI to send tasks to an ECS cluster](#extending-with-ecs) where you can run your builds in Docker.
+You can get around many of these limitations by [configuring LambCI to send tasks to an ECS/Fargate cluster](#extending-with-ecs) where you can run your builds in Docker.
 
 ## Installation
 
@@ -200,7 +200,7 @@ lambci config --project gh/mhart/kinesalite notifications.slack.channel '#someot
 ```
 
 
-### Config file overrides
+### Configuration file overrides
 
 Here's an example `package.json` overriding the `cmd` property:
 


### PR DESCRIPTION
Updating with new Lambda runtime and memory limits.
Updating abbreviation.
Noting Fargate is another option for long-running container tasks.