### PR TITLE
Parameterize Memory and Length in CloudFormation Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ future, depending on the API they settle on)
 ## Current Limitations (due to the Lambda environment itself)
 
 * No root access
-* 5 min max build time
+* 15 min max build time
 * Bring-your-own-binaries – Lambda has a limited selection of installed software
-* 1.5GB max memory
+* 3GB max memory
 * Linux only
 
 You can get around many of these limitations by [configuring LambCI to send tasks to an ECS cluster](#extending-with-ecs) where you can run your builds in Docker.

--- a/lambci.template
+++ b/lambci.template
@@ -34,6 +34,20 @@
       "Default": "#general",
       "AllowedPattern": "^$|^#.+",
       "ConstraintDescription": "Must be empty or a valid Slack channel, eg: #general"
+    },
+    "LambdaMemory": {
+      "Description": "Lambda (MB increments of 128) [128, 256, ... 3008]",
+      "Type": "String",
+      "Default": "3008",
+      "AllowedPattern": "^[0-9]*$",
+      "ConstraintDescription": "Must be a number starting at 128 in increments of 128 to a max of 3008, eg: 1536"
+    },
+    "LambdaTimeout": {
+      "Description": "Lambda Timeout (Seconds) [1 ... 900]",
+      "Type": "String",
+      "Default": "900",
+      "AllowedPattern": "^[0-9]*$",
+      "ConstraintDescription": "Must be a number from 1 to 900, eg: 900"
     }
   },
   "Resources": {
@@ -43,8 +57,8 @@
         "FunctionName": {"Fn::Join": ["", [{"Ref": "AWS::StackName"}, "-build"]]},
         "Description": {"Fn::Join": ["", ["LambCI build function for stack: ", {"Ref": "AWS::StackName"}]]},
         "Handler": "index.handler",
-        "MemorySize": "1536",
-        "Timeout": "300",
+        "MemorySize": {"Ref": "LambdaMemory"},
+        "Timeout": {"Ref": "LambdaTimeout"},
         "Role": {"Fn::GetAtt": ["LambdaExecution", "Arn"]},
         "Code": {
           "S3Bucket": {"Fn::Join": ["", ["lambci-", {"Ref": "AWS::Region"}]]},


### PR DESCRIPTION
Updates to Lambda limits allow us to increase memory to 3008 mb and timeout to 900 seconds. These should be parameterized in the cloudformation template to allow configuring that setting while deploying.

Tested in my account and everything looks good.

![](https://i.imgur.com/thfUQey.png)

![](https://i.imgur.com/035ZnCp.png)
