### PR TITLE
Properly shutdown lambda for docker builds and subscribe to github status event to properly end ecs builds

### DIFF
--- a/actions/build.js
+++ b/actions/build.js
@@ -1,8 +1,8 @@
 var path = require('path')
-var EventEmitter = require('events')
 var spawn = require('child_process').spawn
 var async = require('neo-async')
 var AWS = require('aws-sdk')
+var BuildInfo = require('./buildInfo.js')
 var utils = require('../utils')
 var log = require('../utils/log')
 var config = require('../utils/config')
@@ -313,63 +313,3 @@ function prepareDockerConfig(buildConfig) {
   }
   return utils.merge(defaultDockerConfig, buildConfig)
 }
-
-function BuildInfo(buildData, context) {
-  this.startedAt = new Date()
-  this.endedAt = null
-
-  this.status = 'pending'
-  this.statusEmitter = new EventEmitter()
-
-  // Any async functions to run on 'finish' should be added to this array,
-  // and be of the form: function(build, cb)
-  this.statusEmitter.finishTasks = []
-
-  this.project = buildData.project
-  this.buildNum = buildData.buildNum || 0
-
-  this.repo = buildData.repo || this.project.replace(/^gh\//, '')
-
-  if (buildData.trigger) {
-    var triggerPieces = buildData.trigger.split('/')
-    this.trigger = buildData.trigger
-    this.eventType = triggerPieces[0] == 'pr' ? 'pull_request' : 'push'
-    this.prNum = triggerPieces[0] == 'pr' ? +triggerPieces[1] : 0
-    this.branch = triggerPieces[0] == 'push' ? triggerPieces[1] : (buildData.branch || 'master')
-  } else {
-    this.eventType = buildData.eventType
-    this.prNum = buildData.prNum
-    this.branch = buildData.branch
-    this.trigger = this.prNum ? `pr/${this.prNum}` : `push/${this.branch}`
-  }
-
-  this.event = buildData.event
-  this.isPrivate = buildData.isPrivate
-  this.isRebuild = buildData.isRebuild
-
-  this.branch = buildData.branch
-  this.cloneRepo = buildData.cloneRepo || this.repo
-  this.checkoutBranch = buildData.checkoutBranch || this.branch
-  this.commit = buildData.commit
-  this.baseCommit = buildData.baseCommit
-  this.comment = buildData.comment
-  this.user = buildData.user
-
-  this.isFork = this.cloneRepo != this.repo
-
-  this.committers = buildData.committers
-
-  this.config = null
-  this.cloneDir = path.join(config.BASE_BUILD_DIR, this.repo)
-
-  this.requestId = context.awsRequestId
-  this.logGroupName = context.logGroupName
-  this.logStreamName = context.logStreamName
-
-  this.token = ''
-  this.logUrl = ''
-  this.lambdaLogUrl = ''
-  this.buildDirUrl = ''
-  this.error = null
-}
-

--- a/actions/buildInfo.js
+++ b/actions/buildInfo.js
@@ -1,0 +1,64 @@
+var path = require('path')
+var config = require('../utils/config')
+var EventEmitter = require('events')
+
+module.exports = BuildInfo
+
+function BuildInfo(buildData, context) {
+  this.startedAt = new Date()
+  this.endedAt = null
+
+  this.status = 'pending'
+  this.statusEmitter = new EventEmitter()
+
+  // Any async functions to run on 'finish' should be added to this array,
+  // and be of the form: function(build, cb)
+  this.statusEmitter.finishTasks = []
+
+  this.project = buildData.project
+  this.buildNum = buildData.buildNum || 0
+
+  this.repo = buildData.repo || this.project.replace(/^gh\//, '')
+
+  if (buildData.trigger) {
+    var triggerPieces = buildData.trigger.split('/')
+    this.trigger = buildData.trigger
+    this.eventType = triggerPieces[0] == 'pr' ? 'pull_request' : 'push'
+    this.prNum = triggerPieces[0] == 'pr' ? +triggerPieces[1] : 0
+    this.branch = triggerPieces[0] == 'push' ? triggerPieces[1] : (buildData.branch || 'master')
+  } else {
+    this.eventType = buildData.eventType
+    this.prNum = buildData.prNum
+    this.branch = buildData.branch
+    this.trigger = this.prNum ? `pr/${this.prNum}` : `push/${this.branch}`
+  }
+
+  this.event = buildData.event
+  this.isPrivate = buildData.isPrivate
+  this.isRebuild = buildData.isRebuild
+
+  this.branch = buildData.branch
+  this.cloneRepo = buildData.cloneRepo || this.repo
+  this.checkoutBranch = buildData.checkoutBranch || this.branch
+  this.commit = buildData.commit
+  this.baseCommit = buildData.baseCommit
+  this.comment = buildData.comment
+  this.user = buildData.user
+
+  this.isFork = this.cloneRepo != this.repo
+
+  this.committers = buildData.committers
+
+  this.config = null
+  this.cloneDir = path.join(config.BASE_BUILD_DIR, this.repo)
+
+  this.requestId = context.awsRequestId
+  this.logGroupName = context.logGroupName
+  this.logStreamName = context.logStreamName
+
+  this.token = ''
+  this.logUrl = ''
+  this.lambdaLogUrl = ''
+  this.buildDirUrl = ''
+  this.error = null
+}

--- a/actions/index.js
+++ b/actions/index.js
@@ -7,6 +7,5 @@ exports.version = function(event, context, cb) {
 }
 
 exports.build = require('./build')
-
 exports.rebuild = require('./rebuild')
-
+exports.updateStatus = require('./updateStatus')

--- a/actions/updateStatus.js
+++ b/actions/updateStatus.js
@@ -1,0 +1,81 @@
+var async = require('neo-async')
+var config = require('../utils/config')
+var db = require('../db')
+var BuildInfo = require('./buildInfo.js')
+var log = require('../utils/log')
+
+module.exports = updateStatus
+
+// For ecs builds the lambda build function exists before the build is finished.
+// The slack message and the github status update are done from inside the ecs container.
+// This results in unfinished builds in dynamodb and s3 objects such as badges
+// won't get updated.
+// To fix this we subscribe to the status-event in github to get notified when
+// the build has finished.
+function updateStatus(event, context, cb) {
+  var build
+
+  // ignore status events for pending
+  if (event.state == "pending") return cb()
+
+  if (!event.repository) {
+    throw new Error('repository field is missing from GitHub event')
+  }
+  var project = `gh/${event.repository.full_name}`
+
+  var matches = (event.description || "").match(/#([0-9]+)/)
+  if ((matches == null) || (matches.length < 2)) {
+    throw new Error('failed to extract build number from description')
+  }
+  var buildNum = parseInt(matches[1])
+
+  // get the lambci config and build info from dynamodb
+  async.parallel({
+    configs: (cb) => db.getConfigs(['global', project], cb),
+    buildInfo: (cb) => db.getBuild(project, buildNum, cb),
+  }, function(err, data) {
+    if (err) return cb(err)
+
+    // only try to fix builds that are still stuck in pending state
+    if (data.buildInfo.status != "pending") return cb()
+
+    data.buildInfo.isRebuild = false
+    data.buildInfo.committers = [data.buildInfo.user]
+
+    var build = new BuildInfo(data.buildInfo, context)
+    build.startedAt = new Date(Date.parse(data.buildInfo.startedAt))
+
+    build.config = config.initConfig(data.configs, build)
+    build.token = build.config.secretEnv.GITHUB_TOKEN
+
+    if (event.state == 'success') {
+      build.status = 'success'
+      log.info(`Build #${build.buildNum} successful!`)
+    } else if (build.status == 'failure') {
+      build.status = 'failure'
+      log.info(`Build #${build.buildNum} failed`)
+    } else {
+      return cb(new Error('unknown build status'))
+    }
+
+    // wait 10s to ensure that the build lambda has had enough time to upload
+    // the log to s3
+    setTimeout(function() {
+      // init logger so that the finish tasks that update s3 objects
+      // (such as badges and log output) get registered.
+      build.logUrl = log.initBuildLog(build)
+
+      // add db to finish tasks so that the build gets marked as done in dynamodb
+      var finishTasks = build.statusEmitter.finishTasks.concat(db.finishBuild)
+
+      // end build
+      build.endedAt = new Date()
+      build.statusEmitter.emit('finish', build)
+
+      async.forEach(finishTasks, (task, cb) => task(build, cb), function(taskErr) {
+        log.logIfErr(taskErr)
+        cb(build.error)
+      })
+    }, 10000);
+  });
+}

--- a/notifications/slack.js
+++ b/notifications/slack.js
@@ -37,6 +37,9 @@ function SlackClient(token, options, build) {
   })
 
   build.statusEmitter.finishTasks.push((build, cb) => {
+    // Don't update statuses if we're doing a docker build and we launched successfully
+    if (!build.error && build.config.docker) return cb()
+
     var status = {}, elapsedTxt = utils.elapsedTxt(build.startedAt, build.endedAt)
     if (build.error) {
       var txt = build.error.message

--- a/sources/github.js
+++ b/sources/github.js
@@ -31,6 +31,9 @@ function GithubClient(build) {
   })
 
   build.statusEmitter.finishTasks.push((build, cb) => {
+    // Don't update statuses if we're doing a docker build and we launched successfully
+    if (!build.error && build.config.docker) return cb()
+
     var status = {
       state: build.error ? 'failure' : 'success',
       description: build.error ? build.error.message : `Build #${build.buildNum} successful!`,

--- a/sources/webhook.js
+++ b/sources/webhook.js
@@ -47,6 +47,23 @@ exports.build = function(event, context, cb) {
       return done(null, {msg: 'pong'})
     }
 
+    if (eventType == 'status') {
+      var innerEvent
+
+      try {
+        innerEvent = JSON.parse(event.body)
+      } catch (e) {
+        throw new Error(`Could not parse webhook body as JSON: ${e.message}`)
+      }
+
+      lambda.invoke({
+        InvocationType: 'Event',
+        FunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+        Payload: JSON.stringify(Object.assign({action: 'updateStatus'}, innerEvent)),
+      }, done)
+      return
+    }
+
     var buildData
 
     try {


### PR DESCRIPTION
Proposed fix for: https://github.com/lambci/ecs/issues/25

This PR contains the following changes:

1. Properly end loguploader after ecs build has started to prevent lambda timeouts
2. Subscribe to status event of github (needs to be enabled in webhook) to fix badges and logs after ecs build has finished

This works but it is sort of hack. Triggering the build lambda from ecs directly might be cleaner than going through github.