### PR TITLE
Pay per request dynamodb tables

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -96,17 +96,16 @@ Resources:
     Type: AWS::Serverless::SimpleTable
     Properties:
       TableName: !Sub ${AWS::StackName}-config
+      BillingMode: PAY_PER_REQUEST
       PrimaryKey:
         Name: project
         Type: String
-      ProvisionedThroughput:
-        ReadCapacityUnits: 1
-        WriteCapacityUnits: 1
 
   BuildsTable:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Sub ${AWS::StackName}-builds
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: project
           AttributeType: S
@@ -123,9 +122,6 @@ Resources:
           KeyType: HASH
         - AttributeName: buildNum
           KeyType: RANGE
-      ProvisionedThroughput:
-        ReadCapacityUnits: 1
-        WriteCapacityUnits: 1
       LocalSecondaryIndexes:
         - IndexName: trigger
           KeySchema:


### PR DESCRIPTION
Changed Dynamodb billing mode from provisioned throughputs to pay per request. to lower idle cost to ZERO + S3 bucket cost